### PR TITLE
remove logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,6 @@ gem 'jekyll', '~> 4.3'
 gem 'rack-jekyll', git: 'https://github.com/adaoraul/rack-jekyll.git',
                    ref: 'a997bd0'
 
-# related https://github.com/jekyll/jekyll/pull/9392
-gem 'logger', '< 1.4.3'
-
 gem 'kramdown-parser-gfm'
 gem 'minima', '~> 2.0'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,6 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.4.2)
     mercenary (0.4.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
@@ -126,7 +125,6 @@ DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-feed (~> 0.6)
   kramdown-parser-gfm
-  logger (< 1.4.3)
   minima (~> 2.0)
   puma
   rack-jekyll!


### PR DESCRIPTION
Now that jekyll works the latest logger gem and released, it's no longer necessary to include this gem as a dependency.

Related:

* https://github.com/jekyll/jekyll/pull/9513
* https://github.com/jekyll/jekyll/pull/9392